### PR TITLE
#2 update for inkdrop 4.x

### DIFF
--- a/lib/slackify.js
+++ b/lib/slackify.js
@@ -13,7 +13,8 @@ function send_to_clipboard(content) {
 }
 
 function convert() {
-    const {codeMirror} = inkdrop.getActiveEditor();
+    const editor = inkdrop.getActiveEditor();
+    const codeMirror = editor.cm;
     const selected_md = codeMirror.getSelection('\n');
     const slackify = require('./SlackifyCompiler');
     const processor = unified().use(markdown).use(slackify, {listItemIndent: '1'});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/Schumi543/inkdrop-slackify",
   "license": "MIT",
   "engines": {
-    "inkdrop": ">=3.7.3 <4.0.0"
+    "inkdrop": "^4.x"
   },
   "dependencies": {
     "remark-parse": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inkdrop-slackify",
   "main": "./lib/slackify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Convert markdown to slack format",
   "keywords": [
     "slack",


### PR DESCRIPTION
As the title

already released as v1.1.0
```
~/gitrepos/github.com/Schumi543/inkdrop-slackify #2-update_for_inkdrop_4.x 6s
❯ ipm publish minor
Preparing and tagging a new version ✓
Pushing v1.1.0 tag ✓
Publishing inkdrop-slackify@v1.1.0 ✓
```